### PR TITLE
카드 / 멤버십 / 기프티콘 API 구현

### DIFF
--- a/src/main/java/com/berryselect/backend/wallet/controller/WalletController.java
+++ b/src/main/java/com/berryselect/backend/wallet/controller/WalletController.java
@@ -6,6 +6,7 @@ import com.berryselect.backend.wallet.dto.request.MembershipCreateRequest;
 import com.berryselect.backend.wallet.dto.response.*;
 import com.berryselect.backend.wallet.service.WalletService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -100,12 +101,31 @@ public class WalletController {
         return ResponseEntity.ok(walletService.getGifticonDetail(userId, gifticonId));
     }
 
-    @PostMapping("/gifticons")
-    public ResponseEntity<GifticonResponse> createGifticon(
+    // 1. 기프티콘 등록 - 번호 등록
+    @PostMapping(value = "/gifticons", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<GifticonResponse> createGifticonJson(
             @RequestHeader(name = "X-User-Id", required = false) Long userIdHeader,
             @RequestBody GifticonCreateRequest req
     ) {
         Long userId = (userIdHeader != null) ? userIdHeader : 1L;
+        return ResponseEntity.ok(walletService.createGifticon(userId, req));
+    }
+
+    // 2. 기프티콘 등록 - 이미지 등록 (이미지는 읽기만 하고 DB 저장 X)
+    @PostMapping(value = "/gifticons", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<GifticonResponse> createGifticonMultipart(
+            @RequestHeader(name = "X-User-Id", required = false) Long userIdHeader,
+            @ModelAttribute GifticonCreateRequest req
+    ) {
+        Long userId = (userIdHeader != null) ? userIdHeader : 1L;
+
+        if (req.getImage() != null && !req.getImage().isEmpty()) {
+            try {
+                byte[] bytes = req.getImage().getBytes();
+                // TODO: 필요 시 OCR/바코드 인식 등 임시 처리 (DB 보관 X)
+            } catch (Exception ignore) { /* 실패해도 등록은 진행 */ }
+        }
+
         return ResponseEntity.ok(walletService.createGifticon(userId, req));
     }
 

--- a/src/main/java/com/berryselect/backend/wallet/controller/WalletController.java
+++ b/src/main/java/com/berryselect/backend/wallet/controller/WalletController.java
@@ -1,4 +1,81 @@
 package com.berryselect.backend.wallet.controller;
 
+import com.berryselect.backend.wallet.dto.request.MembershipCreateRequest;
+import com.berryselect.backend.wallet.dto.response.AssetResponse;
+import com.berryselect.backend.wallet.dto.response.MembershipResponse;
+import com.berryselect.backend.wallet.dto.response.MembershipSummaryResponse;
+import com.berryselect.backend.wallet.dto.response.WalletSummaryResponse;
+import com.berryselect.backend.wallet.service.WalletService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/wallet")
+@RequiredArgsConstructor
 public class WalletController {
+    private final WalletService walletService;
+
+    /**
+     * =====================
+     * Card
+     * =====================
+     */
+    @GetMapping("/cards")
+    public ResponseEntity<WalletSummaryResponse> listCards(
+            @RequestHeader(name = "X-User-Id", required = false) Long userIdHeader
+    ) {
+        Long userId = (userIdHeader != null) ? userIdHeader : 1L;  // Security 연동 전 임시
+        return ResponseEntity.ok(walletService.getCardList(userId));
+    }
+
+    @GetMapping("/cards/{cardId}")
+    public ResponseEntity<AssetResponse> getCard(
+            @RequestHeader(name = "X-User-Id", required = false) Long userIdHeader,
+            @PathVariable Long cardId
+    ) {
+        Long userId = (userIdHeader != null) ? userIdHeader : 1L;
+        return ResponseEntity.ok(walletService.getCardDetail(userId, cardId));
+    }
+
+    /**
+     * =====================
+     * Membership
+     * =====================
+     */
+    @GetMapping("/memberships")
+    public ResponseEntity<MembershipSummaryResponse> listMemberships(
+            @RequestHeader(name = "X-User-Id", required = false) Long userIdHeader
+    ) {
+        Long userId = (userIdHeader != null) ? userIdHeader : 1L;
+        return ResponseEntity.ok(walletService.getMembershipList(userId));
+    }
+
+    @GetMapping("/memberships/{membershipId}")
+    public ResponseEntity<MembershipResponse> getMembership(
+            @RequestHeader(name = "X-User-Id", required = false) Long userIdHeader,
+            @PathVariable Long membershipId
+    ) {
+        Long userId = (userIdHeader != null) ? userIdHeader : 1L;
+        return ResponseEntity.ok(walletService.getMembershipDetail(userId, membershipId));
+    }
+
+    @PostMapping("/memberships")
+    public ResponseEntity<MembershipResponse> createMembership(
+            @RequestHeader(name = "X-User-Id", required = false) Long userIdHeader,
+            @RequestBody MembershipCreateRequest req
+    ) {
+        Long userId = (userIdHeader != null) ? userIdHeader : 1L;
+        return ResponseEntity.ok(walletService.createMembership(userId, req));
+    }
+
+    @DeleteMapping("/memberships/{membershipId}")
+    public ResponseEntity<Void> deleteMembership(
+            @RequestHeader(name = "X-User-Id", required = false) Long userIdHeader,
+            @PathVariable Long membershipId
+    ) {
+        Long userId = (userIdHeader != null) ? userIdHeader : 1L;
+        walletService.deleteMembership(userId, membershipId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/berryselect/backend/wallet/controller/WalletController.java
+++ b/src/main/java/com/berryselect/backend/wallet/controller/WalletController.java
@@ -1,10 +1,9 @@
 package com.berryselect.backend.wallet.controller;
 
+import com.berryselect.backend.wallet.domain.type.GifticonStatus;
+import com.berryselect.backend.wallet.dto.request.GifticonCreateRequest;
 import com.berryselect.backend.wallet.dto.request.MembershipCreateRequest;
-import com.berryselect.backend.wallet.dto.response.AssetResponse;
-import com.berryselect.backend.wallet.dto.response.MembershipResponse;
-import com.berryselect.backend.wallet.dto.response.MembershipSummaryResponse;
-import com.berryselect.backend.wallet.dto.response.WalletSummaryResponse;
+import com.berryselect.backend.wallet.dto.response.*;
 import com.berryselect.backend.wallet.service.WalletService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -76,6 +75,68 @@ public class WalletController {
     ) {
         Long userId = (userIdHeader != null) ? userIdHeader : 1L;
         walletService.deleteMembership(userId, membershipId);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * =====================
+     * Gifticon
+     * =====================
+     */
+    @GetMapping("/gifticons")
+    public ResponseEntity<GifticonSummaryResponse> listGifticons(
+            @RequestHeader(name = "X-User-Id", required = false) Long userIdHeader
+    ) {
+        Long userId = (userIdHeader != null) ? userIdHeader : 1L;
+        return ResponseEntity.ok(walletService.getGifticonList(userId));
+    }
+
+    @GetMapping("/gifticons/{gifticonId}")
+    public ResponseEntity<GifticonResponse> getGifticon(
+            @RequestHeader(name = "X-User-Id", required = false) Long userIdHeader,
+            @PathVariable Long gifticonId
+    ) {
+        Long userId = (userIdHeader != null) ? userIdHeader : 1L;
+        return ResponseEntity.ok(walletService.getGifticonDetail(userId, gifticonId));
+    }
+
+    @PostMapping("/gifticons")
+    public ResponseEntity<GifticonResponse> createGifticon(
+            @RequestHeader(name = "X-User-Id", required = false) Long userIdHeader,
+            @RequestBody GifticonCreateRequest req
+    ) {
+        Long userId = (userIdHeader != null) ? userIdHeader : 1L;
+        return ResponseEntity.ok(walletService.createGifticon(userId, req));
+    }
+
+    @PutMapping("/gifticons/{gifticonId}")
+    public ResponseEntity<GifticonResponse> updateGifticonStatus(
+            @RequestHeader(name = "X-User-Id", required = false) Long userIdHeader,
+            @PathVariable Long gifticonId,
+            @RequestParam("status") GifticonStatus gifticonStatus
+    ) {
+        Long userId = (userIdHeader != null) ? userIdHeader : 1L;
+        return ResponseEntity.ok(walletService.updateGifticonStatus(userId, gifticonId, gifticonStatus));
+    }
+
+    @DeleteMapping("/gifticons/{gifticonId}")
+    public ResponseEntity<Void> deleteGifticon(
+            @RequestHeader(name = "X-User-Id", required = false) Long userIdHeader,
+            @PathVariable Long gifticonId
+    ) {
+        Long userId = (userIdHeader != null) ? userIdHeader : 1L;
+        walletService.deleteGifticon(userId, gifticonId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/gifticons/{gifticonId}/redeem")
+    public ResponseEntity<Void> redeemGifticon(
+            @RequestHeader(name = "X-User-Id", required = false) Long userIdHeader,
+            @PathVariable Long gifticonId,
+            @RequestParam Integer usedAmount
+    ) {
+        Long userId = (userIdHeader != null) ? userIdHeader : 1L;
+        walletService.redeemGifticon(userId, gifticonId, usedAmount);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/berryselect/backend/wallet/domain/AssetType.java
+++ b/src/main/java/com/berryselect/backend/wallet/domain/AssetType.java
@@ -1,4 +1,4 @@
-package com.berryselect.backend.wallet.domain.type;
+package com.berryselect.backend.wallet.domain;
 
 public enum AssetType {
     CARD, MEMBERSHIP, GIFTICON

--- a/src/main/java/com/berryselect/backend/wallet/domain/GifticonRedemption.java
+++ b/src/main/java/com/berryselect/backend/wallet/domain/GifticonRedemption.java
@@ -1,4 +1,29 @@
 package com.berryselect.backend.wallet.domain;
 
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "gifticon_redemptions")
+@Getter
+@Setter
 public class GifticonRedemption {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "asset_id", nullable = false)
+    private UserAsset asset;
+
+    @Column(name = "tx_id")
+    private Long txId;
+
+    @Column(name = "used_amount", nullable = false)
+    private Integer usedAmount;
+
+    @Column(name = "redeemeed_at", nullable = false)
+    private LocalDateTime redeemedAt;
 }

--- a/src/main/java/com/berryselect/backend/wallet/domain/Product.java
+++ b/src/main/java/com/berryselect/backend/wallet/domain/Product.java
@@ -3,7 +3,6 @@ package com.berryselect.backend.wallet.domain;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
-import com.berryselect.backend.wallet.domain.type.AssetType;
 
 @Entity
 @Table(name = "products")

--- a/src/main/java/com/berryselect/backend/wallet/domain/Product.java
+++ b/src/main/java/com/berryselect/backend/wallet/domain/Product.java
@@ -1,5 +1,6 @@
 package com.berryselect.backend.wallet.domain;
 
+import com.berryselect.backend.wallet.domain.type.AssetType;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/berryselect/backend/wallet/domain/Product.java
+++ b/src/main/java/com/berryselect/backend/wallet/domain/Product.java
@@ -1,4 +1,25 @@
 package com.berryselect.backend.wallet.domain;
 
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import com.berryselect.backend.wallet.domain.type.AssetType;
+
+@Entity
+@Table(name = "products")
+@Getter
+@Setter
 public class Product {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "product_type", nullable = false, length = 20)
+    private AssetType productType;  // CARD/MEMBERSHIP/GIFTICON
+
+    @Column(length = 60)
+    private String issuer;  // 카드사
+
+    @Column(nullable = false, length = 255)
+    private String name;
 }

--- a/src/main/java/com/berryselect/backend/wallet/domain/UserAsset.java
+++ b/src/main/java/com/berryselect/backend/wallet/domain/UserAsset.java
@@ -1,6 +1,5 @@
 package com.berryselect.backend.wallet.domain;
 
-import com.berryselect.backend.wallet.domain.type.AssetType;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/berryselect/backend/wallet/domain/UserAsset.java
+++ b/src/main/java/com/berryselect/backend/wallet/domain/UserAsset.java
@@ -1,4 +1,49 @@
 package com.berryselect.backend.wallet.domain;
 
+import com.berryselect.backend.wallet.domain.type.AssetType;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "user_assets")
+@Getter
+@Setter
 public class UserAsset {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "asset_type", nullable = false, length = 20)
+    private AssetType assetType;  // CARD/MEMBERSHIP/GIFTICON
+
+    @Column(length = 4)
+    private String last4;
+
+    @Column(name = "this_month_spend")
+    private Long thisMonthSpend;
+
+    @Column(name = "external_no")
+    private String externalNo;
+
+    private Integer balance;
+    private String barcode;
+    private String level;
+    private Integer priority;
+
+    @Column(name = "limit_expected")
+    private Integer limitExpected;
+
+    private LocalDate expiredAt;
+    private String status;
 }
+

--- a/src/main/java/com/berryselect/backend/wallet/domain/UserAsset.java
+++ b/src/main/java/com/berryselect/backend/wallet/domain/UserAsset.java
@@ -1,5 +1,7 @@
 package com.berryselect.backend.wallet.domain;
 
+import com.berryselect.backend.wallet.domain.type.AssetType;
+import com.berryselect.backend.wallet.domain.type.GifticonStatus;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -25,6 +27,10 @@ public class UserAsset {
     @Column(name = "asset_type", nullable = false, length = 20)
     private AssetType assetType;  // CARD/MEMBERSHIP/GIFTICON
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "gifticon_status")
+    private GifticonStatus gifticonStatus;  // ACTIVE/USED/EXPIRED
+
     @Column(length = 4)
     private String last4;
 
@@ -42,7 +48,6 @@ public class UserAsset {
     @Column(name = "limit_expected")
     private Integer limitExpected;
 
-    private LocalDate expiredAt;
-    private String status;
+    private LocalDate expiresAt;
 }
 

--- a/src/main/java/com/berryselect/backend/wallet/domain/type/AssetType.java
+++ b/src/main/java/com/berryselect/backend/wallet/domain/type/AssetType.java
@@ -1,4 +1,4 @@
-package com.berryselect.backend.wallet.domain;
+package com.berryselect.backend.wallet.domain.type;
 
 public enum AssetType {
     CARD, MEMBERSHIP, GIFTICON

--- a/src/main/java/com/berryselect/backend/wallet/domain/type/AssetType.java
+++ b/src/main/java/com/berryselect/backend/wallet/domain/type/AssetType.java
@@ -1,0 +1,5 @@
+package com.berryselect.backend.wallet.domain.type;
+
+public enum AssetType {
+    CARD, MEMBERSHIP, GIFTICON
+}

--- a/src/main/java/com/berryselect/backend/wallet/domain/type/GifticonStatus.java
+++ b/src/main/java/com/berryselect/backend/wallet/domain/type/GifticonStatus.java
@@ -1,0 +1,7 @@
+package com.berryselect.backend.wallet.domain.type;
+
+public enum GifticonStatus {
+    ACTIVE,
+    USED,
+    EXPIRED
+}

--- a/src/main/java/com/berryselect/backend/wallet/dto/request/AssetUpsertRequest.java
+++ b/src/main/java/com/berryselect/backend/wallet/dto/request/AssetUpsertRequest.java
@@ -1,4 +1,0 @@
-package com.berryselect.backend.wallet.dto.request;
-
-public class AssetUpsertRequest {
-}

--- a/src/main/java/com/berryselect/backend/wallet/dto/request/GifticonCreateRequest.java
+++ b/src/main/java/com/berryselect/backend/wallet/dto/request/GifticonCreateRequest.java
@@ -1,0 +1,9 @@
+package com.berryselect.backend.wallet.dto.request;
+
+public record GifticonCreateRequest(
+        Long productId,  // 기프티콘 상품 ID
+        String barcode,  // 바코드 값
+        Integer balance,  // 잔액
+        String expiresAt  // 만료일 (yyyy-MM-dd)
+) {
+}

--- a/src/main/java/com/berryselect/backend/wallet/dto/request/GifticonCreateRequest.java
+++ b/src/main/java/com/berryselect/backend/wallet/dto/request/GifticonCreateRequest.java
@@ -1,9 +1,19 @@
 package com.berryselect.backend.wallet.dto.request;
 
-public record GifticonCreateRequest(
-        Long productId,  // 기프티콘 상품 ID
-        String barcode,  // 바코드 값
-        Integer balance,  // 잔액
-        String expiresAt  // 만료일 (yyyy-MM-dd)
-) {
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+
+public class GifticonCreateRequest {
+        private Long productId;  // 기프티콘 상품 ID
+        private String barcode;  // 바코드 값
+        private Integer balance;  // 잔액
+        private String expiresAt;  // 만료일 (yyyy-MM-dd)
+        @JsonIgnore private MultipartFile image;  // Json 역직렬화 무시(멀티파트에서만 바인딩)
 }

--- a/src/main/java/com/berryselect/backend/wallet/dto/request/MembershipCreateRequest.java
+++ b/src/main/java/com/berryselect/backend/wallet/dto/request/MembershipCreateRequest.java
@@ -1,0 +1,8 @@
+package com.berryselect.backend.wallet.dto.request;
+
+public record MembershipCreateRequest(
+        Long productId,
+        String externalNo,  // 멤버십 번호
+        String level  // 등급
+) {
+}

--- a/src/main/java/com/berryselect/backend/wallet/dto/response/AssetResponse.java
+++ b/src/main/java/com/berryselect/backend/wallet/dto/response/AssetResponse.java
@@ -1,4 +1,10 @@
 package com.berryselect.backend.wallet.dto.response;
 
-public class AssetResponse {
-}
+public record AssetResponse (
+    Long id,
+    String type,  // "CARD"
+    String productName,  // 카드 상품명
+    String issuer,  // 카드사
+    String last4,
+    Long thisMonthSpend
+) { }

--- a/src/main/java/com/berryselect/backend/wallet/dto/response/GifticonResponse.java
+++ b/src/main/java/com/berryselect/backend/wallet/dto/response/GifticonResponse.java
@@ -1,0 +1,14 @@
+package com.berryselect.backend.wallet.dto.response;
+
+import com.berryselect.backend.wallet.domain.type.GifticonStatus;
+
+public record GifticonResponse(
+        Long id,
+        String type,  // "GIFTICON"
+        String name,
+        String barcode,
+        Integer balance,
+        String expiresAt,
+        GifticonStatus gifticonStatus  // ACTIVE/USED/EXPIRED
+) {
+}

--- a/src/main/java/com/berryselect/backend/wallet/dto/response/GifticonSummaryResponse.java
+++ b/src/main/java/com/berryselect/backend/wallet/dto/response/GifticonSummaryResponse.java
@@ -1,0 +1,19 @@
+package com.berryselect.backend.wallet.dto.response;
+
+import com.berryselect.backend.wallet.domain.type.GifticonStatus;
+
+import java.util.List;
+
+public record GifticonSummaryResponse(
+        String type,
+        List<GifticonSummary> items
+) {
+    public record GifticonSummary(
+            Long id,
+            String name,
+            String barcode,
+            Integer balance,
+            String expiresAt,
+            GifticonStatus gifticonStatus  // ACTIVE/USED/EXPIRED
+    ) {}
+}

--- a/src/main/java/com/berryselect/backend/wallet/dto/response/MembershipResponse.java
+++ b/src/main/java/com/berryselect/backend/wallet/dto/response/MembershipResponse.java
@@ -1,0 +1,10 @@
+package com.berryselect.backend.wallet.dto.response;
+
+public record MembershipResponse(
+        Long id,
+        String type,  // "MEMBERSHIP"
+        String productName,
+        String externalNo,  // 멤버십 번호
+        String level  // 등급
+) {
+}

--- a/src/main/java/com/berryselect/backend/wallet/dto/response/MembershipSummaryResponse.java
+++ b/src/main/java/com/berryselect/backend/wallet/dto/response/MembershipSummaryResponse.java
@@ -1,0 +1,15 @@
+package com.berryselect.backend.wallet.dto.response;
+
+import java.util.List;
+
+public record MembershipSummaryResponse(
+        String type,  // "MEMBERSHIP"
+        List<MembershipSummary> items
+) {
+    public record MembershipSummary(
+            Long id,
+            String productName,
+            String externalNo,
+            String level
+    ) { }
+}

--- a/src/main/java/com/berryselect/backend/wallet/dto/response/WalletSummaryResponse.java
+++ b/src/main/java/com/berryselect/backend/wallet/dto/response/WalletSummaryResponse.java
@@ -1,4 +1,16 @@
 package com.berryselect.backend.wallet.dto.response;
 
-public class WalletSummaryResponse {
+import java.util.List;
+
+public record WalletSummaryResponse (
+        String type,  // "CARD"
+        List<AssetSummary> items
+) {
+    public record AssetSummary(
+            Long id,
+            String productName,
+            String issuer,
+            String last4,
+            Long thisMonthSpend
+    ) { }
 }

--- a/src/main/java/com/berryselect/backend/wallet/mapper/WalletMapper.java
+++ b/src/main/java/com/berryselect/backend/wallet/mapper/WalletMapper.java
@@ -1,10 +1,7 @@
 package com.berryselect.backend.wallet.mapper;
 
 import com.berryselect.backend.wallet.domain.UserAsset;
-import com.berryselect.backend.wallet.dto.response.AssetResponse;
-import com.berryselect.backend.wallet.dto.response.MembershipResponse;
-import com.berryselect.backend.wallet.dto.response.MembershipSummaryResponse;
-import com.berryselect.backend.wallet.dto.response.WalletSummaryResponse;
+import com.berryselect.backend.wallet.dto.response.*;
 
 public final class WalletMapper {
     private WalletMapper() {}
@@ -56,6 +53,34 @@ public final class WalletMapper {
                 ua.getProduct().getName(),
                 ua.getExternalNo(),
                 ua.getLevel()
+        );
+    }
+
+    /**
+     * =====================
+     * Gifticon
+     * =====================
+     */
+    public static GifticonSummaryResponse.GifticonSummary toGifticonSummary(UserAsset ua) {
+        return new GifticonSummaryResponse.GifticonSummary(
+                ua.getId(),
+                ua.getProduct().getName(),
+                ua.getBarcode(),
+                ua.getBalance(),
+                ua.getExpiresAt() != null ? ua.getExpiresAt().toString() : null,
+                ua.getGifticonStatus()
+        );
+    }
+
+    public static GifticonResponse toGifticonDetail(UserAsset ua) {
+        return new GifticonResponse(
+                ua.getId(),
+                "GIFTICON",
+                ua.getProduct().getName(),
+                ua.getBarcode(),
+                ua.getBalance(),
+                ua.getExpiresAt() != null ? ua.getExpiresAt().toString() : null,
+                ua.getGifticonStatus()
         );
     }
 }

--- a/src/main/java/com/berryselect/backend/wallet/mapper/WalletMapper.java
+++ b/src/main/java/com/berryselect/backend/wallet/mapper/WalletMapper.java
@@ -1,4 +1,61 @@
 package com.berryselect.backend.wallet.mapper;
 
-public class WalletMapper {
+import com.berryselect.backend.wallet.domain.UserAsset;
+import com.berryselect.backend.wallet.dto.response.AssetResponse;
+import com.berryselect.backend.wallet.dto.response.MembershipResponse;
+import com.berryselect.backend.wallet.dto.response.MembershipSummaryResponse;
+import com.berryselect.backend.wallet.dto.response.WalletSummaryResponse;
+
+public final class WalletMapper {
+    private WalletMapper() {}
+
+    /**
+     * =====================
+     * Card
+     * =====================
+     */
+    public static WalletSummaryResponse.AssetSummary toCardSummary(UserAsset ua) {
+        return new WalletSummaryResponse.AssetSummary(
+                ua.getId(),
+                ua.getProduct().getName(),
+                ua.getProduct().getIssuer(),
+                ua.getLast4(),
+                ua.getThisMonthSpend()
+        );
+    }
+
+    public static AssetResponse toCardDetail(UserAsset ua) {
+        return new AssetResponse(
+                ua.getId(),
+                "CARD",
+                ua.getProduct().getName(),
+                ua.getProduct().getIssuer(),
+                ua.getLast4(),
+                ua.getThisMonthSpend()
+        );
+    }
+
+    /**
+     * =====================
+     * Membership
+     * =====================
+     */
+    public static MembershipSummaryResponse.MembershipSummary toMembershipSummary(UserAsset ua) {
+        return new MembershipSummaryResponse.MembershipSummary(
+                ua.getId(),
+                ua.getProduct().getName(),
+                ua.getExternalNo(),
+                ua.getLevel()
+        );
+    }
+
+    public static MembershipResponse toMembershipDetail(UserAsset ua) {
+        return new MembershipResponse(
+                ua.getId(),
+                "MEMBERSHIP",
+                ua.getProduct().getName(),
+                ua.getExternalNo(),
+                ua.getLevel()
+        );
+    }
 }

--- a/src/main/java/com/berryselect/backend/wallet/repository/GifticonRedemptionRepository.java
+++ b/src/main/java/com/berryselect/backend/wallet/repository/GifticonRedemptionRepository.java
@@ -1,4 +1,7 @@
 package com.berryselect.backend.wallet.repository;
 
-public class GifticonRedemptionRepository {
+import com.berryselect.backend.wallet.domain.GifticonRedemption;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GifticonRedemptionRepository extends JpaRepository<GifticonRedemption, Long> {
 }

--- a/src/main/java/com/berryselect/backend/wallet/repository/ProductRepository.java
+++ b/src/main/java/com/berryselect/backend/wallet/repository/ProductRepository.java
@@ -1,4 +1,7 @@
 package com.berryselect.backend.wallet.repository;
 
-public class ProductRepository {
+import com.berryselect.backend.wallet.domain.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
 }

--- a/src/main/java/com/berryselect/backend/wallet/repository/UserAssetRepository.java
+++ b/src/main/java/com/berryselect/backend/wallet/repository/UserAssetRepository.java
@@ -1,7 +1,7 @@
 package com.berryselect.backend.wallet.repository;
 
 import com.berryselect.backend.wallet.domain.UserAsset;
-import com.berryselect.backend.wallet.domain.AssetType;
+import com.berryselect.backend.wallet.domain.type.AssetType;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/com/berryselect/backend/wallet/repository/UserAssetRepository.java
+++ b/src/main/java/com/berryselect/backend/wallet/repository/UserAssetRepository.java
@@ -1,4 +1,19 @@
 package com.berryselect.backend.wallet.repository;
 
-public class UserAssetRepository {
+import com.berryselect.backend.wallet.domain.UserAsset;
+import com.berryselect.backend.wallet.domain.type.AssetType;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface UserAssetRepository extends JpaRepository<UserAsset, Long> {
+    List<UserAsset> findByUserId(String userId);
+
+    @EntityGraph(attributePaths = "product")
+    List<UserAsset> findByUserIdAndAssetTypeOrderByIdDesc(Long userId, AssetType assetType);
+
+    @EntityGraph(attributePaths = "product")
+    Optional<UserAsset> findByIdAndUserIdAndAssetType(Long id, Long userId, AssetType assetType);
 }

--- a/src/main/java/com/berryselect/backend/wallet/repository/UserAssetRepository.java
+++ b/src/main/java/com/berryselect/backend/wallet/repository/UserAssetRepository.java
@@ -1,7 +1,7 @@
 package com.berryselect.backend.wallet.repository;
 
 import com.berryselect.backend.wallet.domain.UserAsset;
-import com.berryselect.backend.wallet.domain.type.AssetType;
+import com.berryselect.backend.wallet.domain.AssetType;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/com/berryselect/backend/wallet/service/WalletService.java
+++ b/src/main/java/com/berryselect/backend/wallet/service/WalletService.java
@@ -1,4 +1,94 @@
 package com.berryselect.backend.wallet.service;
 
+import com.berryselect.backend.wallet.domain.UserAsset;
+import com.berryselect.backend.wallet.domain.type.AssetType;
+import com.berryselect.backend.wallet.dto.request.MembershipCreateRequest;
+import com.berryselect.backend.wallet.dto.response.AssetResponse;
+import com.berryselect.backend.wallet.dto.response.MembershipResponse;
+import com.berryselect.backend.wallet.dto.response.MembershipSummaryResponse;
+import com.berryselect.backend.wallet.dto.response.WalletSummaryResponse;
+import com.berryselect.backend.wallet.mapper.WalletMapper;
+import com.berryselect.backend.wallet.repository.ProductRepository;
+import com.berryselect.backend.wallet.repository.UserAssetRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
 public class WalletService {
+    private final UserAssetRepository userAssetRepository;
+    private final ProductRepository productRepository;
+
+    /**
+     * =====================
+     * Card
+     * =====================
+     */
+    @Transactional(readOnly = true)
+    public WalletSummaryResponse getCardList(Long userId) {
+        var items = userAssetRepository
+                .findByUserIdAndAssetTypeOrderByIdDesc(userId, AssetType.CARD)
+                .stream()
+                .map(WalletMapper::toCardSummary)
+                .toList();
+        return new WalletSummaryResponse("CARD", items);
+    }
+
+    @Transactional(readOnly = true)
+    public AssetResponse getCardDetail(Long userId, Long cardId) {
+        UserAsset ua = userAssetRepository
+                .findByIdAndUserIdAndAssetType(cardId, userId, AssetType.CARD)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Card not found"));
+        return WalletMapper.toCardDetail(ua);
+    }
+
+    /**
+     * =====================
+     * Membership
+     * =====================
+     */
+    @Transactional(readOnly = true)
+    public MembershipSummaryResponse getMembershipList(Long userId) {
+        var items = userAssetRepository
+                .findByUserIdAndAssetTypeOrderByIdDesc(userId, AssetType.MEMBERSHIP)
+                .stream()
+                .map(WalletMapper::toMembershipSummary)
+                .toList();
+        return new MembershipSummaryResponse("MEMBERSHIP", items);
+    }
+
+    @Transactional(readOnly = true)
+    public MembershipResponse getMembershipDetail(Long userId, Long membershipId) {
+        UserAsset ua = userAssetRepository
+                .findByIdAndUserIdAndAssetType(membershipId, userId, AssetType.MEMBERSHIP)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Membership not found"));
+        return WalletMapper.toMembershipDetail(ua);
+    }
+
+    @Transactional
+    public MembershipResponse createMembership(Long userId, MembershipCreateRequest req) {
+        UserAsset ua = new UserAsset();
+        ua.setUserId(userId);
+        ua.setProduct(
+                productRepository.findById(req.productId())
+                        .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid product"))
+        );
+        ua.setAssetType(AssetType.MEMBERSHIP);
+        ua.setExternalNo(req.externalNo());
+        ua.setLevel(req.level());
+
+        UserAsset saved = userAssetRepository.save(ua);
+        return WalletMapper.toMembershipDetail(saved);
+    }
+
+    @Transactional
+    public void deleteMembership(Long userId, Long membershipId) {
+        UserAsset ua = userAssetRepository
+                .findByIdAndUserIdAndAssetType(membershipId, userId, AssetType.MEMBERSHIP)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Membership not found"));
+        userAssetRepository.delete(ua);
+    }
 }

--- a/src/main/java/com/berryselect/backend/wallet/service/WalletService.java
+++ b/src/main/java/com/berryselect/backend/wallet/service/WalletService.java
@@ -122,13 +122,13 @@ public class WalletService {
         UserAsset ua = new UserAsset();
         ua.setUserId(userId);
         ua.setProduct(
-                productRepository.findById(req.productId())
+                productRepository.findById(req.getProductId())
                         .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid product"))
         );
         ua.setAssetType(AssetType.GIFTICON);
-        ua.setBarcode(req.barcode());
-        ua.setBalance(req.balance());
-        ua.setExpiresAt(req.expiresAt() != null ? java.time.LocalDate.parse(req.expiresAt()) : null);
+        ua.setBarcode(req.getBarcode());
+        ua.setBalance(req.getBalance());
+        ua.setExpiresAt(req.getExpiresAt() != null ? java.time.LocalDate.parse(req.getExpiresAt()) : null);
         ua.setGifticonStatus(GifticonStatus.ACTIVE);
 
         UserAsset saved = userAssetRepository.save(ua);

--- a/src/main/java/com/berryselect/backend/wallet/service/WalletService.java
+++ b/src/main/java/com/berryselect/backend/wallet/service/WalletService.java
@@ -1,7 +1,7 @@
 package com.berryselect.backend.wallet.service;
 
 import com.berryselect.backend.wallet.domain.UserAsset;
-import com.berryselect.backend.wallet.domain.type.AssetType;
+import com.berryselect.backend.wallet.domain.AssetType;
 import com.berryselect.backend.wallet.dto.request.MembershipCreateRequest;
 import com.berryselect.backend.wallet.dto.response.AssetResponse;
 import com.berryselect.backend.wallet.dto.response.MembershipResponse;


### PR DESCRIPTION
## 🔗 반영 브랜치

(#1 , #2 , #3 ) feature/wallet -> develop

## 📝 작업 내용

1. 카드 READ API (목록, 상세 조회)
2. 멤버십 CRUD API (등록, 조회, 삭제)
3. 기프티콘 CRUD + 이미지/번호 등록 포함 & 사용 처리 및 사용 내역 & 상태 변경 API
     - 이미지 등록 : 이미지는 DB에 저장되지 않고, 요청 시 처리만 하도록 구현
     - 사용 처리 : ACTIVE/USED/EXPIRED

## 💬 리뷰 요구사항(선택 사항)